### PR TITLE
Add customizable logger

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,6 +2,8 @@ require "spec"
 require "timecop"
 require "../src/http-protection"
 
+HTTP::Protection::Logger.instance = Logger.new(IO::Memory.new)
+
 def context_for_tests : HTTP::Server::Context
   HTTP::Server::Context.new(
     HTTP::Request.new("GET", "/", HTTP::Headers.new),

--- a/src/http-protection/base.cr
+++ b/src/http-protection/base.cr
@@ -1,11 +1,15 @@
 module HTTP::Protection
   class Base
+    def logger
+      Logger.instance
+    end
+
     def html?(context)
       content_types = [
         "text/html",
         "text/html;charset=utf-8",
         "application/xhtml",
-        "application/xhtml+xml"
+        "application/xhtml+xml",
       ]
 
       content_types.includes?(context.request.headers["Content-Type"])
@@ -23,7 +27,7 @@ module HTTP::Protection
         "GET",
         "HEAD",
         "OPTIONS",
-        "TRACE"
+        "TRACE",
       ]
 
       methods.includes?(context.request.headers["REQUEST_METHOD"])

--- a/src/http-protection/deflect.cr
+++ b/src/http-protection/deflect.cr
@@ -15,7 +15,7 @@
 #  HTTP::Protection::Deflect.new(interval: 5, duration: 5, threshold: 10, blacklist: ["111.111.111.111"], whitelist: ["222.222.222.222"])
 #
 module HTTP::Protection
-  class Deflect
+  class Deflect < Base
     include HTTP::Handler
 
     def initialize(@interval : Int32 = 5, @duration : Int32 = 900, @threshold : Int32 = 100, @blacklist : Array(String) = [] of String, @whitelist : Array(String) = [] of String)
@@ -23,9 +23,6 @@ module HTTP::Protection
 
       @mapper = {} of String => Hash(String, Int32 | Int64)
       @remote = ""
-
-      @logger = Logger.new(STDOUT)
-      @logger.level = Logger::WARN
     end
 
     def call(context)
@@ -48,8 +45,8 @@ module HTTP::Protection
 
     private def map
       @mapper[@remote] ||= {
-        "expires" => Time.epoch(Time.now.epoch + @interval).epoch_ms,
-        "requests" => 0
+        "expires"  => Time.epoch(Time.now.epoch + @interval).epoch_ms,
+        "requests" => 0,
       }
     end
 
@@ -76,7 +73,7 @@ module HTTP::Protection
 
       map["block_expires"] = Time.epoch(Time.now.epoch + @duration).epoch_ms
 
-      @logger.warn("#{@remote} blocked")
+      logger.warn("#{@remote} blocked")
     end
 
     private def clear!
@@ -84,7 +81,7 @@ module HTTP::Protection
 
       @mapper.delete(@remote)
 
-      @logger.warn("#{@remote} released") if blocked?
+      logger.warn("#{@remote} released") if blocked?
     end
 
     private def blocked?

--- a/src/http-protection/logger.cr
+++ b/src/http-protection/logger.cr
@@ -1,0 +1,6 @@
+module HTTP::Protection
+  class Logger
+    class_property instance : ::Logger = ::Logger.new(STDOUT)
+    @@instance.level = ::Logger::WARN
+  end
+end

--- a/src/http-protection/origin.cr
+++ b/src/http-protection/origin.cr
@@ -16,19 +16,17 @@ module HTTP::Protection
     include HTTP::Handler
 
     DEFAULT_PORTS = {
-      "http" => 80,
-      "https" => 443
+      "http"  => 80,
+      "https" => 443,
     }
 
     def initialize(@whitelist : Array(String) = [] of String)
-      @logger = Logger.new(STDOUT)
-      @logger.level = Logger::WARN
     end
 
     def call(context)
       return call_next(context) if accepts?(context)
 
-      @logger.warn("origin '#{origin(context)}' unauthorized ")
+      logger.warn("origin '#{origin(context)}' unauthorized ")
 
       context.response.headers["Content-Type"] = "text/plain"
       context.response.headers["Content-Length"] = "0"


### PR DESCRIPTION
Hi @rogeriozambon, I'm happy to see more brazilians in Crystal community! :smile: 

This PR makes possible to use a custom logger instead of always writing to STDOUT, thus we can use a null logger on specs to make output clearer.

Before:
```
$ crystal spec
.W, [2017-09-13 13:14:27 -0300 #22361]  WARN -- : 111.111.111.111 blocked
.W, [2017-09-13 13:14:27 -0300 #22361]  WARN -- : 111.111.111.111 blocked
.............................W, [2017-09-13 13:14:27 -0300 #22361]  WARN -- : origin 'http://malicious.com' unauthorized 
..W, [2017-09-13 13:14:27 -0300 #22361]  WARN -- : origin 'http://malicious.com' unauthorized 
..W, [2017-09-13 13:14:27 -0300 #22361]  WARN -- : origin 'http://malicious.com' unauthorized 
.........................

Finished in 3.01 milliseconds
60 examples, 0 failures, 0 errors, 0 pending
```

After:
```
$ crystal spec
............................................................

Finished in 2.88 milliseconds
60 examples, 0 failures, 0 errors, 0 pending
```

WDYT?