### PR TITLE
FrameOption should check response content-type and ignore charset

### DIFF
--- a/spec/http-protection/frame_options_spec.cr
+++ b/spec/http-protection/frame_options_spec.cr
@@ -9,7 +9,7 @@ describe HTTP::Protection::FrameOptions do
   end
 
   it "should set the X-Frame-Options" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
 
     middleware = HTTP::Protection::FrameOptions.new
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
@@ -27,7 +27,7 @@ describe HTTP::Protection::FrameOptions do
   end
 
   it "should allow changing the protection mode" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
 
     middleware = HTTP::Protection::FrameOptions.new(option: "DENY")
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
@@ -37,7 +37,7 @@ describe HTTP::Protection::FrameOptions do
   end
 
   it "should allow changing the protection mode to a string" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
 
     middleware = HTTP::Protection::FrameOptions.new(option: "ALLOW-FROM foo")
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
@@ -47,7 +47,7 @@ describe HTTP::Protection::FrameOptions do
   end
 
   it "should not override the header if already set" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
     context.response.headers["X-Frame-Options"] = "allow"
 
     middleware = HTTP::Protection::FrameOptions.new
@@ -58,7 +58,7 @@ describe HTTP::Protection::FrameOptions do
   end
 
   it "should set the X-Frame-Options also when charset is specified" do
-    context.request.headers.add("Content-Type", "text/html;charset=utf-8")
+    context.response.headers.add("Content-Type", "text/html;charset=utf-8")
 
     middleware = HTTP::Protection::FrameOptions.new
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }

--- a/spec/http-protection/frame_options_spec.cr
+++ b/spec/http-protection/frame_options_spec.cr
@@ -56,4 +56,14 @@ describe HTTP::Protection::FrameOptions do
 
     context.response.headers["X-Frame-Options"].should eq("allow")
   end
+
+  it "should set the X-Frame-Options also when charset is specified" do
+    context.request.headers.add("Content-Type", "text/html;charset=utf-8")
+
+    middleware = HTTP::Protection::FrameOptions.new
+    middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
+    middleware.call(context)
+
+    context.response.headers["X-Frame-Options"].should eq("SAMEORIGIN")
+  end
 end

--- a/spec/http-protection/xss_header_spec.cr
+++ b/spec/http-protection/xss_header_spec.cr
@@ -12,7 +12,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should set the X-XSS-Protection" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
     middleware.call(context)
 
     headers = context.response.headers
@@ -20,7 +20,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should set the X-XSS-Protection for XHTML" do
-    context.request.headers.add("Content-Type", "application/xhtml+xml")
+    context.response.headers.add("Content-Type", "application/xhtml+xml")
     middleware.call(context)
 
     headers = context.response.headers
@@ -28,7 +28,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should not set the X-XSS-Protection for other content types" do
-    context.request.headers.add("Content-Type", "application/foo")
+    context.response.headers.add("Content-Type", "application/foo")
     middleware.call(context)
 
     headers = context.response.headers
@@ -36,7 +36,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should allow changing the protection mode" do
-    context.request.headers.add("Content-Type", "application/xhtml")
+    context.response.headers.add("Content-Type", "application/xhtml")
 
     middleware = HTTP::Protection::XSSHeader.new(xss_mode: "foo")
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
@@ -47,7 +47,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should not override the header if already set" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
     context.request.headers.add("X-XSS-Protection", "0")
 
     middleware.call(context)
@@ -57,7 +57,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should set the X-Content-Type-Options" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
     middleware.call(context)
 
     headers = context.response.headers
@@ -65,7 +65,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should set the X-Content-Type-Options for other content types" do
-    context.request.headers.add("Content-Type", "application/foo")
+    context.response.headers.add("Content-Type", "application/foo")
     middleware.call(context)
 
     headers = context.response.headers
@@ -73,7 +73,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should allow changing the nosniff-mode off" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
 
     middleware = HTTP::Protection::XSSHeader.new(nosniff: false)
     middleware.next = ->(ctx : HTTP::Server::Context) { called = true }
@@ -84,7 +84,7 @@ describe HTTP::Protection::XSSHeader do
   end
 
   it "should not override the header if already set X-Content-Type-Options" do
-    context.request.headers.add("Content-Type", "text/html")
+    context.response.headers.add("Content-Type", "text/html")
     context.request.headers.add("X-Content-Type-Options", "sniff")
 
     middleware.call(context)

--- a/src/http-protection.cr
+++ b/src/http-protection.cr
@@ -1,3 +1,2 @@
-require "logger"
 require "http/server"
 require "./http-protection/*"

--- a/src/http-protection/base.cr
+++ b/src/http-protection/base.cr
@@ -4,11 +4,7 @@ module HTTP::Protection
       Logger.instance
     end
 
-    HTML_CONTENT_TYPES = [
-      "text/html",
-      "application/xhtml",
-      "application/xhtml+xml",
-    ]
+    HTML_CONTENT_TYPES = %w[text/html application/xhtml]
 
     def html?(context)
       content_type = context.request.headers["Content-Type"]
@@ -22,12 +18,7 @@ module HTTP::Protection
       headers.fetch("Origin") { nil } || headers.fetch("HTTP_ORIGIN") { nil } || headers.fetch("HTTP_X_ORIGIN") { nil }
     end
 
-    SAFE_METHODS = [
-      "GET",
-      "HEAD",
-      "OPTIONS",
-      "TRACE",
-    ]
+    SAFE_METHODS = %w[GET HEAD OPTIONS TRACE]
 
     def safe?(context)
       SAFE_METHODS.includes?(context.request.method)

--- a/src/http-protection/base.cr
+++ b/src/http-protection/base.cr
@@ -4,14 +4,15 @@ module HTTP::Protection
       Logger.instance
     end
 
-    def html?(context)
-      content_types = [
-        "text/html",
-        "application/xhtml",
-        "application/xhtml+xml",
-      ]
+    HTML_CONTENT_TYPES = [
+      "text/html",
+      "application/xhtml",
+      "application/xhtml+xml",
+    ]
 
-      content_types.includes?(context.request.headers["Content-Type"])
+    def html?(context)
+      content_type = context.request.headers["Content-Type"]
+      HTML_CONTENT_TYPES.any? { |ct| content_type.starts_with? ct }
     rescue
       false
     end

--- a/src/http-protection/base.cr
+++ b/src/http-protection/base.cr
@@ -7,7 +7,7 @@ module HTTP::Protection
     HTML_CONTENT_TYPES = %w[text/html application/xhtml]
 
     def html?(context)
-      content_type = context.request.headers["Content-Type"]
+      content_type = context.response.headers["Content-Type"]
       HTML_CONTENT_TYPES.any? { |ct| content_type.starts_with? ct }
     rescue
       false

--- a/src/http-protection/base.cr
+++ b/src/http-protection/base.cr
@@ -22,15 +22,15 @@ module HTTP::Protection
       headers.fetch("Origin") { nil } || headers.fetch("HTTP_ORIGIN") { nil } || headers.fetch("HTTP_X_ORIGIN") { nil }
     end
 
-    def safe?(context)
-      methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "TRACE",
-      ]
+    SAFE_METHODS = [
+      "GET",
+      "HEAD",
+      "OPTIONS",
+      "TRACE",
+    ]
 
-      methods.includes?(context.request.method)
+    def safe?(context)
+      SAFE_METHODS.includes?(context.request.method)
     rescue
       false
     end

--- a/src/http-protection/frame_options.cr
+++ b/src/http-protection/frame_options.cr
@@ -19,8 +19,8 @@ module HTTP::Protection
     end
 
     def call(context : HTTP::Server::Context)
-      context.response.headers["X-Frame-Options"] ||= @option if html?(context)
       call_next(context)
+      context.response.headers["X-Frame-Options"] ||= @option if html?(context)
     end
   end
 end


### PR DESCRIPTION
If content type was `text/html;charset=utf8` the frame option wasn't set. 